### PR TITLE
upgrade trumpet to 1.6.5 fixes #12

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,17 +26,19 @@ module.exports = function harmon(reqselectors, resselectors) {
 
 			var _write = res.write;
 			var _end = res.end;
-            var _writeHead = res.writeHead
+            var _writeHead = res.writeHead;
 
-			res.write = function (data) {
-				tr.write(data);
+			res.write = function (data, encoding) {
+				tr.write(data, encoding);
 			};
 
 			res.end = function (data, encoding) {
-				data && tr.end(data, encoding);
-				tr.end();
-				_end.call(res);
+				tr.end(data, encoding);
 			};
+
+			tr.on('end', function () {
+				_end.call(res);
+			});
 
 			tr.on('data', function (buf) {
 				_write.call(res, buf);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/No9/harmon/issues"
   },
   "dependencies": {
-    "trumpet": "1.6.3"
+    "trumpet": "1.6.5"
   },
   "devDependencies": {
     "tap": "0.4.0",

--- a/test/host.js
+++ b/test/host.js
@@ -104,7 +104,7 @@ test('Streams can change the response size', function (t) {
     t.plan(1);
 
     var server2 = http.createServer(function (req, res) {
-        s = '<body><p>hi</p></body>';
+        var s = '<body><p>hi</p></body>';
         res.setHeader('Content-length', '' + s.length);  // All ASCII today
         res.end(s);
     }).listen(9001);


### PR DESCRIPTION
API changed and calling original `_end` in the `res.end` was no longer good enough, as only some data was sent back.  This fixes it and updates `trumpet` to `1.6.5`.

There is also 2 minor style/global leak fixes.
