### PR TITLE
Proxied non html content 'Content-Encoding' header is removed but the content is not unzipped

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,14 @@ module.exports = function harmonBinary(reqSelectors, resSelectors, htmlOnly) {
 
   function prepareRequestSelectors(req, res) {
     var tr = trumpet();
-  
+
     prepareSelectors(tr, _reqSelectors, req, res);
-    
+
     req.on('data', function(data) {
       tr.write(data);
     });
   }
-    
+
   function prepareResponseSelectors(req, res) {
     var tr          = trumpet();
     var _write      = res.write;
@@ -27,29 +27,14 @@ module.exports = function harmonBinary(reqSelectors, resSelectors, htmlOnly) {
 
     // Assume response is binary by default
     res.isHtml = false;
-    
+
     // Assume response is uncompressed by default
     res.isGziped = false;
 
     res.writeHead = function (code, headers) {
       var contentType = this.getHeader('content-type');
-      
+
       var contentEncoding = this.getHeader('content-encoding');
-
-
-      /* Sniff out the content-type header.
-       * If the response is Gziped, we're have to gunzip content before and ungzip content after.
-       */
-      if (contentEncoding && contentEncoding.toLowerCase() == 'gzip') {
-        res.isGziped = true;
-
-        // Strip off the content encoding since it will change.
-        res.removeHeader('Content-Encoding');
-
-        if (headers) {
-          delete headers['content-encoding'];
-        }
-      }
 
       /* Sniff out the content-type header.
        * If the response is HTML, we're safe to modify it.
@@ -64,10 +49,24 @@ module.exports = function harmonBinary(reqSelectors, resSelectors, htmlOnly) {
           delete headers['content-length'];
         }
       }
-      
+
+      /* Sniff out the content-type header.
+       * If the response is Gziped, we're have to gunzip content before and ungzip content after.
+       */
+      if (res.isHtml && contentEncoding && contentEncoding.toLowerCase() == 'gzip') {
+          res.isGziped = true;
+
+          // Strip off the content encoding since it will change.
+          res.removeHeader('Content-Encoding');
+
+          if (headers) {
+              delete headers['content-encoding'];
+          }
+     }
+
       _writeHead.apply(res, arguments);
     };
-    
+
     res.write = function (data, encoding) {
       // Only run data through trumpet if we have HTML
       if (res.isHtml) {
@@ -117,7 +116,7 @@ module.exports = function harmonBinary(reqSelectors, resSelectors, htmlOnly) {
       })(selectors[i].func, req, res);
     }
   }
-    
+
   return function harmonBinary(req, res, next) {
     var ignore = false;
 


### PR DESCRIPTION
## The Problem
When using the isHtml flag=true all proxied content has the 'Content-Encoding' [removed](https://github.com/No9/harmon/blob/master/index.js#L43-52). If the content is not an html the gzipped data is written to the stream even-though the 'Content-Encoding' was not set nor is the unzipped data [written](https://github.com/No9/harmon/blob/master/index.js#L80)

## My Solution
The solution was to simply [check](https://github.com/Jhorlin/harmon/blob/master/index.js#L56) before removing the 'Content-Encoding' header.
I have written test to verify the fix.
