### PR TITLE
Support writeHead overload specifying a status code message

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,11 @@ module.exports = function harmonBinary(reqSelectors, resSelectors, htmlOnly) {
     // Assume response is uncompressed by default
     res.isGziped = false;
 
-    res.writeHead = function (code, headers) {
-      var contentType = this.getHeader('content-type');
+    res.writeHead = function () {
+      var code = arguments[0];
+      var headers = (arguments.length > 2) ? arguments[2] : arguments[1]; // writeHead supports (statusCode, headers) as well as (statusCode, statusMessage, headers)
 
+      var contentType = this.getHeader('content-type');
       var contentEncoding = this.getHeader('content-encoding');
 
       /* Sniff out the content-type header.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "colors": "^0.6.2",
     "connect": "^3.2.0",
-    "http-proxy": "^1.1.2",
+    "http-proxy": "~1.14",
     "tap": "0.4.0"
   },
   "scripts": {


### PR DESCRIPTION
This allows handlers (such as [node-http-proxy](/nodejitsu/node-http-proxy)) being called after harmon to specify a status code message with the status code when calling "writeHead". The Node.js documentation specifies the writeHead signature as being: response.writeHead(statusCode[, statusMessage][, headers])

This commit makes harmon's writeHead patch properly handle both overloads to the response.writeHead method.